### PR TITLE
Fix a compile warning.

### DIFF
--- a/KKGestureLockView/Source/KKGestureLockView.m
+++ b/KKGestureLockView/Source/KKGestureLockView.m
@@ -264,7 +264,7 @@ const static CGFloat kTrackedLocationInvalidInContentView = -1.0;
     
     _delegateFlags.didBeginWithPasscode = [delegate respondsToSelector:@selector(gestureLockView:didBeginWithPasscode:)];
     _delegateFlags.didEndWithPasscode = [delegate respondsToSelector:@selector(gestureLockView:didEndWithPasscode:)];
-    _delegateFlags.didCanceled = [delegate respondsToSelector:@selector(gestureLockViewCanceled:)];
+    _delegateFlags.didCanceled = [delegate respondsToSelector:@selector(gestureLockView:didCanceledWithPasscode:)];
 }
 
 - (void)setNumberOfGestureNodes:(NSUInteger)numberOfGestureNodes{


### PR DESCRIPTION
This is caused by the wrong function name in @Selector().
